### PR TITLE
feat: Add WooCommerce SourceBuster support

### DIFF
--- a/src/addons/addons.php
+++ b/src/addons/addons.php
@@ -30,6 +30,7 @@ namespace cybot\cookiebot\addons {
 	use cybot\cookiebot\addons\controller\addons\simple_share_buttons_adder\Simple_Share_Buttons_Adder;
 	use cybot\cookiebot\addons\controller\addons\wd_google_analytics\Wd_Google_Analytics;
 	use cybot\cookiebot\addons\controller\addons\woocommerce_google_analytics_pro\Woocommerce_Google_Analytics_Pro;
+	use cybot\cookiebot\addons\controller\addons\woocommerce_sourcebuster\WooCommerce_SourceBuster;
 	use cybot\cookiebot\addons\controller\addons\wp_analytify\Wp_Analytify;
 	use cybot\cookiebot\addons\controller\addons\wp_google_analytics_events\Wp_Google_Analytics_Events;
 	use cybot\cookiebot\addons\controller\addons\wp_mautic\Wp_Mautic;
@@ -58,6 +59,7 @@ namespace cybot\cookiebot\addons {
 		Optinmonster::class,
 		Pixel_Caffeine::class,
 		Woocommerce_Google_Analytics_Pro::class,
+		WooCommerce_SourceBuster::class,
 		Wp_Analytify::class,
 		Wp_Google_Analytics_Events::class,
 		Wp_Mautic::class,

--- a/src/addons/controller/addons/woocommerce_sourcebuster/WooCommerce_SourceBuster.php
+++ b/src/addons/controller/addons/woocommerce_sourcebuster/WooCommerce_SourceBuster.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace cybot\cookiebot\addons\controller\addons\woocommerce_sourcebuster;
+
+use cybot\cookiebot\addons\controller\addons\Base_Cookiebot_Plugin_Addon;
+
+class WooCommerce_SourceBuster extends Base_Cookiebot_Plugin_Addon {
+
+	const ADDON_NAME                 = 'WooCommerce Source Buster';
+	const DEFAULT_COOKIE_TYPES       = array( 'statistics' );
+	const ENABLE_ADDON_BY_DEFAULT    = true;
+	const OPTION_NAME                = 'woocommerce_sourcebuster';
+	const PLUGIN_FILE_PATH           = 'woocommerce/woocommerce.php';
+
+	/**
+	 * Manipulate the scripts if they are loaded.
+	 *
+	 * @since 4.4.0
+	 */
+	public function load_addon_configuration() {
+		$this->script_loader_tag->add_tag( 'sourcebuster-js', $this->get_cookie_types() );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_extra_information() {
+		return array(
+			__(
+				'Blocks the WooCommerce "Order Attribution Tracking" / "SourceBuster" before cookies accepted.',
+				'cookiebot'
+			),
+		);
+	}
+}


### PR DESCRIPTION
This commit adds WooCommerce SourceBuster support to block WooCommerce Order Attribution Tracking script until user accepts cookies (default is statistics).

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integration for WooCommerce Order Attribution Tracking (SourceBuster) to block its tracking until user consent is given.
  * Enabled by default and categorized under Statistics cookies for easier compliance.
  * Automatically activates when WooCommerce is detected; manageable from the Add-ons settings.
  * Includes in-app information describing the behavior and impact of the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->